### PR TITLE
Remove updating positions for blasts from the BlastSystem

### DIFF
--- a/src/systems/blast.rs
+++ b/src/systems/blast.rs
@@ -37,11 +37,6 @@ impl<'s> System<'s> for BlastSystem {
                     .delete(blast_entity)
                     .expect("unable to delete entity");
             }
-
-            // update position based on blast velocity
-            blast_transform.prepend_translation_x(blast_motion2d.velocity.x * time.delta_seconds());
-            blast_transform
-                .prepend_translation_y((blast_motion2d.velocity.y) * time.delta_seconds());
         }
     }
 }


### PR DESCRIPTION
Since we now have a general system responsible for updating positions for entities with a motion2d component, we are also updating the blast positions a second time from the BlastSystem and causing them to move faster. 

This patch removes that logic for updating the blasts from the BlastSystem.