### PR TITLE
[blasts] Introduce limited range for blasts via DespawnTimeLimitComponent

### DIFF
--- a/thetawave_game/src/data_include/data/mobs.ron
+++ b/thetawave_game/src/data_include/data/mobs.ron
@@ -134,6 +134,7 @@
                 crit_chance: 0.0,
                 size_multiplier: 1.0,
                 spacing: 7.0,
+                range: 200.0,
             )),
             autofire_component: Some((
                 period: 3.0,
@@ -277,6 +278,7 @@
                 crit_chance: 0.0,
                 size_multiplier: 1.0,
                 spacing: 7.0,
+                range: 300.0,
             )),
             autofire_component: Some((
                 period: 3.0,
@@ -358,6 +360,7 @@
                 crit_chance: 0.0,
                 size_multiplier: 1.0,
                 spacing: 7.0,
+                range: 300.0,
             )),
             autofire_component: Some((
                 period: 3.0,

--- a/thetawave_lib/src/entities/spaceship.rs
+++ b/thetawave_lib/src/entities/spaceship.rs
@@ -84,6 +84,7 @@ pub fn initialize_spaceship(world: &mut World, sprite_sheet_handle: Handle<Sprit
         crit_chance: 0.0,
         size_multiplier: 1.0,
         spacing: 7.0,
+        range: 100.0,
     };
 
     let manual_fire = ManualFireComponent {

--- a/thetawave_lib/src/spawnable/resources/mod.rs
+++ b/thetawave_lib/src/spawnable/resources/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     entities::SpawnableType,
     motion::components::{Hitbox2DComponent, Motion2DComponent},
     resources::SpriteSheetsResource,
-    spawn::components::DespawnAtBorderComponent,
+    spawn::components::{DespawnAtBorderComponent, DespawnTimeLimitComponent},
     spawnable::components::BlastComponent,
 };
 use amethyst::{
@@ -90,6 +90,7 @@ pub fn spawn_blasts(
     blast_component: BlastComponent,
     blast_hitbox: Hitbox2DComponent,
     blast_motion2d: Motion2DComponent,
+    despawn_time: f32,
     mut blast_transform: Transform,
     entities: &Entities,
     lazy_update: &ReadExpect<LazyUpdate>,
@@ -103,6 +104,10 @@ pub fn spawn_blasts(
             .with(blast_sprite_render.clone())
             .with(blast_transform.clone())
             .with(Transparent)
+            .with(DespawnTimeLimitComponent {
+                duration: despawn_time,
+            })
+            // Also despawn at the border to avoid tracking entities that left the screen
             .with(DespawnAtBorderComponent {
                 top_offset: Some(2.0),
                 bottom_offset: Some(-2.0),

--- a/thetawave_lib/src/weapons/components/weapons.rs
+++ b/thetawave_lib/src/weapons/components/weapons.rs
@@ -46,6 +46,8 @@ pub struct BlasterComponent {
     pub size_multiplier: f32,
     /// Spacing between fired blasts (when count > 1)
     pub spacing: f32,
+    /// Range of the fired blast
+    pub range: f32,
 }
 
 impl Component for BlasterComponent {
@@ -157,6 +159,7 @@ impl BlasterComponent {
             blast_component,
             blast_hitbox,
             blast_motion2d,
+            self.range / self.shot_velocity.norm(),
             blast_transform,
             entities,
             lazy_update,


### PR DESCRIPTION
Add a DespawnTimeLimitComponent to blasts to have them despawn after a
fixed time based on weapon range and shot velocity

Keep the current behavior of despawning at the border to avoid tracking
blasts that are off the screen

Closes #155